### PR TITLE
Revert to previous state

### DIFF
--- a/sistema_gestion_mejorado_modulos/modulo_reportes.py
+++ b/sistema_gestion_mejorado_modulos/modulo_reportes.py
@@ -218,7 +218,6 @@ class ReportesUI:
                 self.labels_metricas[key].config(text="Error")
 
     def refrescar_automatico(self):
-        # Aquí solo debe refrescar dashboard, sin lógica de sincronización ni botones extra
-        self.parent.after(60000, self.actualizar_dashboard)
+        pass  # Deshabilitado, solo actualización manual
 
     # ... Métodos para generar reportes, mostrar dashboard, etc ... 


### PR DESCRIPTION
Revert `refrescar_automatico()` to disable automatic dashboard refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-e795a28e-4c3f-4ea3-84ba-a60ddb4f79b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e795a28e-4c3f-4ea3-84ba-a60ddb4f79b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

